### PR TITLE
feat: support key expires

### DIFF
--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -4,6 +4,7 @@
 -- using ngx.shared.dict:get_keys (see https://github.com/openresty/lua-nginx-module#ngxshareddictget_keys),
 -- which blocks all workers and therefore it shouldn't be used with large
 -- amounts of keys.
+local ngx_sleep = ngx.sleep
 
 local KeyIndex = {}
 KeyIndex.__index = KeyIndex
@@ -16,6 +17,7 @@ function KeyIndex.new(shared_dict, prefix)
   self.key_count = prefix .. "key_count"
   self.last = 0
   self.deleted = 0
+  self.expired_max_index = 2
   self.keys = {}
   self.index = {}
   return self
@@ -33,6 +35,7 @@ function KeyIndex:sync()
     -- Sync only new keys, if there are any.
     self:sync_range(self.last, N)
   end
+  self:sync_expired(N)
   return N
 end
 
@@ -48,8 +51,27 @@ function KeyIndex:sync_range(first, last)
       self.index[self.keys[i]] = nil
       self.keys[i] = nil
     end
+    ngx_sleep(0)
   end
   self.last = last
+end
+
+function KeyIndex:sync_expired(N)
+  local first = self.expired_max_index
+  --- the key is sorted by created time, so the key will expire in order
+  for i = first, N do
+    -- Read i-th key. If it is nil, it means it was expired
+    local key = self.dict:get(self.key_prefix .. i)
+    if key then
+      break
+    elseif self.keys[i] then
+      -- we don't need to update self.delete_count and self.key_count
+      self.index[self.keys[i]] = nil
+      self.keys[i] = nil
+      self.expired_max_index = i
+    end
+    ngx_sleep(0)
+  end
 end
 
 -- Returns array of all keys.
@@ -71,7 +93,7 @@ end
 --
 -- Returns:
 --   nil on success, string with error message otherwise
-function KeyIndex:add(key_or_keys, err_msg_lru_eviction)
+function KeyIndex:add(key_or_keys, err_msg_lru_eviction, exptime)
   local keys = key_or_keys
   if type(key_or_keys) == "string" then
     keys = { key_or_keys }
@@ -85,7 +107,7 @@ function KeyIndex:add(key_or_keys, err_msg_lru_eviction)
         break
       end
       N = N+1
-      local ok, err, forcible = self.dict:add(self.key_prefix .. N, key)
+      local ok, err, forcible = self.dict:add(self.key_prefix .. N, key, exptime)
       if ok then
         local _, _, forcible2 = self.dict:incr(self.key_count, 1, 0)
         self.keys[N] = key

--- a/prometheus_resty_counter.lua
+++ b/prometheus_resty_counter.lua
@@ -33,7 +33,8 @@ local id
 local function sync(_, self)
   local err, _, forcible
   local ok = true
-  for k, v in pairs(self.increments) do
+  for k, value in pairs(self.increments) do
+    local v = value.v
     _, err, forcible = self.dict:incr(k, v, 0)
     if forcible then
       ngx.log(ngx.ERR, "increasing counter in shdict: lru eviction: key=", k)
@@ -42,6 +43,9 @@ local function sync(_, self)
     if err then
       ngx.log(ngx.ERR, "error increasing counter in shdict key: ", k, ", err: ", err)
       ok = false
+    end
+    if value.t then
+      self.dict:expire(k, value.t)
     end
   end
 
@@ -89,22 +93,27 @@ function _M:sync()
   return sync(false, self)
 end
 
-function _M:incr(key, step)
+function _M:incr(key, step, exptime)
   step = step or 1
-  local v = self.increments[key]
-  if v then
-    step = step + v
+  local value = self.increments[key]
+  if value then
+    step = step + value.v
   end
 
-  self.increments[key] = step
+  -- error("================= levy exptime: " .. exptime)
+  self.increments[key] = {v = step, t = exptime}
   return true
 end
 
-function _M:reset(key, number)
+function _M:reset(key, number, exptime)
   if not number then
     return nil, "expect a number at #2"
   end
-  return self.dict:incr(key, -number, number)
+  local newval, err, forcible = self.dict:incr(key, -number, number)
+  if exptime then
+    self.dict:expire(key, exptime)
+  end
+  return newval, err, forcible
 end
 
 function _M:get(key)

--- a/prometheus_resty_counter.lua
+++ b/prometheus_resty_counter.lua
@@ -100,7 +100,6 @@ function _M:incr(key, step, exptime)
     step = step + value.v
   end
 
-  -- error("================= levy exptime: " .. exptime)
   self.increments[key] = {v = step, t = exptime}
   return true
 end

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -2,7 +2,6 @@
 luaunit = require('luaunit')
 rex_pcre2 = require('rex_pcre2')
 
-
 -- Simple implementation of a nginx shared dictionary
 local SimpleDict = {}
 SimpleDict.__index = SimpleDict

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -63,6 +63,17 @@ function SimpleDict:expire(k, exptime)
   end
   self.dict[k]["expired"] = os.time() + exptime
 end
+function SimpleDict:ttl(k)
+  self:get(k)
+  if not self.dict[k] then
+    return nil, "not found"
+  end
+  if self.dict[k]["expired"] then
+    return self.dict[k]["expired"] - os.time()
+  else
+    return 0
+  end
+end
 
 local function sleep(n)
   local t0 = os.time()

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -1,6 +1,3 @@
-package.path = '/home/liuwei/.luarocks/share/lua/5.1/?.lua;./?.lua;'
-package.cpath = '/home/liuwei/.luarocks/lib/lua/5.1/?.so;'
-
 -- vim: ts=2:sw=2:sts=2:expandtab
 luaunit = require('luaunit')
 rex_pcre2 = require('rex_pcre2')

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -1,25 +1,34 @@
+package.path = '/home/liuwei/.luarocks/share/lua/5.1/?.lua;./?.lua;'
+package.cpath = '/home/liuwei/.luarocks/lib/lua/5.1/?.so;'
+
 -- vim: ts=2:sw=2:sts=2:expandtab
 luaunit = require('luaunit')
 rex_pcre2 = require('rex_pcre2')
 
+
 -- Simple implementation of a nginx shared dictionary
 local SimpleDict = {}
 SimpleDict.__index = SimpleDict
-function SimpleDict:set(k, v)
+function SimpleDict:set(k, v, exptime)
   local forcible = false
   if k == "willnotfitk" or v == "willnotfitv" then
     forcible = true
   end
   if not self.dict then self.dict = {} end
-  self.dict[k] = v
+  if not v then
+    self.dict[k] = nil
+  else
+    local expired = exptime and (os.time() + exptime)
+    self.dict[k] = {value = v, expired = expired}
+  end
   return true, nil, forcible
 end
-function SimpleDict:add(k, v)
+function SimpleDict:add(k, v, exptime)
   local forcible = false
   if k == "willnotfitk" or v == "willnotfitv" then
     forcible = true
   end
-  self:set(k, v)
+  self:set(k, v, exptime)
   return true, nil, forcible  -- ok, err, forcible
 end
 function SimpleDict:incr(k, v, init)
@@ -27,9 +36,9 @@ function SimpleDict:incr(k, v, init)
   if k == "willnotfitk" or v == "willnotfitv" then
     forcible = true
   end
-  if not self.dict[k] then self.dict[k] = init end
-  self.dict[k] = self.dict[k] + (v or 1)
-  return self.dict[k], nil, forcible  -- newval, err, forcible
+  if not self.dict[k] then self.dict[k] = {value = init} end
+  self.dict[k]["value"] = self.dict[k]["value"] + (v or 1)
+  return self.dict[k]["value"], nil, forcible  -- newval, err, forcible
 end
 function SimpleDict:get(k)
   -- simulate key not exist
@@ -41,10 +50,23 @@ function SimpleDict:get(k)
     return nil, "dict error"
   end
   if not self.dict then self.dict = {} end
-  return self.dict[k], nil  -- value, err
+  if self.dict[k] and self.dict[k]["expired"] and self.dict[k]["expired"] < os.time() then self.dict[k] = nil end
+  local v = self.dict[k] or {}
+  return v["value"], nil  -- value, err
 end
 function SimpleDict:delete(k)
   self.dict[k] = nil
+end
+function SimpleDict:expire(k, exptime)
+  if not self.dict[k] then
+    return nil, "not found"
+  end
+  self.dict[k]["expired"] = os.time() + exptime
+end
+
+local function sleep(n)
+  local t0 = os.time()
+  while os.time() - t0 <= n do end
 end
 
 -- Global nginx object
@@ -112,6 +134,10 @@ function TestPrometheus:setUp()
   self.gauge2 = self.p:gauge("gauge2", "Gauge 2", {"f2", "f1"})
   self.hist1 = self.p:histogram("l1", "Histogram 1")
   self.hist2 = self.p:histogram("l2", "Histogram 2", {"var", "site"})
+  self.counter_exp = self.p:counter("metric_exp", "Metric expire", nil, 1)
+  self.gauge_exp = self.p:gauge("gauge_exp", "Gauge expire", nil, 1)
+  self.gauge_exp_2 = self.p:gauge("gauge_exp_2", "Gauge expire 2", nil, 1)
+  self.hist_exp = self.p:histogram("l_exp", "Histogram expire", nil, nil, 1)
 end
 function TestPrometheus.tearDown()
   ngx.logs = nil
@@ -849,7 +875,69 @@ function TestPrometheus.testPrintfTable()
   luaunit.assertEquals(p._table_to_string({"foo"}), "<foo>")
   luaunit.assertEquals(p._table_to_string({"foo",2,"bar"}), "<foo,2,bar>")
   -- table ends at the first value before nil.
-  luaunit.assertEquals(p._table_to_string({nil,2,nil,"foo",nil}), "<nil,2>")
+  luaunit.assertEquals(p._table_to_string({nil,2,nil,"foo",nil}), "<nil,2,nil,foo>")
+end
+
+function TestPrometheus:testKeyTimeout()
+  self.counter_exp:inc(1)
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric_exp"), 1)
+  local i = self.p.key_index.index["metric_exp"]
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), "metric_exp")
+  luaunit.assertEquals(self.p.key_index.keys[i], "metric_exp")
+
+  sleep(1)
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("metric_exp"), nil)
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), nil)
+  luaunit.assertEquals(self.p.key_index.index["metric_exp"], nil)
+  luaunit.assertEquals(self.p.key_index.keys[i], nil)
+
+  self.gauge_exp:inc(1)
+  luaunit.assertEquals(self.dict:get("gauge_exp"), 1)
+  local i = self.p.key_index.index["gauge_exp"]
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), "gauge_exp")
+  luaunit.assertEquals(self.p.key_index.keys[i], "gauge_exp")
+
+  sleep(1)
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("gauge_exp"), nil)
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), nil)
+  luaunit.assertEquals(self.p.key_index.index["gauge_exp"], nil)
+  luaunit.assertEquals(self.p.key_index.keys[i], nil)
+
+  self.gauge_exp_2:set(1)
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("gauge_exp_2"), 1)
+  local i = self.p.key_index.index["gauge_exp_2"]
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), "gauge_exp_2")
+  luaunit.assertEquals(self.p.key_index.keys[i], "gauge_exp_2")
+
+  sleep(1)
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("gauge_exp_2"), nil)
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), nil)
+  luaunit.assertEquals(self.p.key_index.index["gauge_exp_2"], nil)
+  luaunit.assertEquals(self.p.key_index.keys[i], nil)
+
+  self.hist_exp:observe(0.35)
+  self.hist_exp:observe(0.4)
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.300"}'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.400"}'), 2)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.500"}'), 2)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="Inf"}'), 2)
+  luaunit.assertEquals(self.dict:get('l_exp_count'), 2)
+  luaunit.assertEquals(self.dict:get('l_exp_sum'), 0.75)
+
+  sleep(1)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.300"}'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.400"}'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="00.500"}'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_bucket{le="Inf"}'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_count'), nil)
+  luaunit.assertEquals(self.dict:get('l_exp_sum'), nil)
+
 end
 
 os.exit(luaunit.run())


### PR DESCRIPTION
The prometheus metrics we record are stored in LRUs, and although there is no memory leakage, the metrics are not eliminated until they reach the upper limit of the LRUs. As the metrics become more and more numerous, the prometheus server consumes more and more CPU when pulling data, and a mechanism is needed to eliminate the outdated data.

related issue: [#9627](https://github.com/apache/apisix/issues/9627)
