### PR TITLE
fix: metric loss when a previously expired metric is re-added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: sudo apt install libpcre2-dev
+      - run: sudo apt install libpcre2-dev libreadline-dev
       - run: pip install hererocks
       # Install latest LuaRocks version plus the Lua version for this build job
       # into 'here' subdirectory.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,13 +25,10 @@ jobs:
       - run: echo $PWD/here/bin >> $GITHUB_PATH
       - run: eval `luarocks path --bin`
       - run: luarocks install luacheck
-      - run: luarocks install luacov-coveralls
       - run: luarocks install luaunit
       - run: luarocks install lrexlib-pcre2
       - run: luacheck --globals ngx -- prometheus.lua prometheus_keys.lua prometheus_resty_counter.lua
       - run: luacheck --globals luaunit rex_pcre2 ngx TestPrometheus TestKeyIndex -- prometheus_test.lua
-      - run: lua -lluacov prometheus_test.lua
-      - run: luacov-coveralls --include ^prometheus
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Only report test coverage for lua 5.1 to avoid doing it twice.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.src.rock
 *.tar.gz
 nginx-lua-prometheus-0.*/**
+.idea

--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -83,6 +83,7 @@ function KeyIndex:sync_range(first, last)
     elseif self.keys[i] then
       self.index[self.keys[i]] = nil
       self.keys[i] = nil
+      self.expire_keys[i] = nil
     end
   end
   self.last = last

--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -119,10 +119,21 @@ function KeyIndex:add(key_or_keys, err_msg_lru_eviction, exptime)
       local N = self:sync()
       if self.index[key] ~= nil then
         -- key already exists, if has exptime, set expire
+        local expired = false
         if exptime then
-          self.dict:expire(self.key_prefix .. self.index[key], exptime)
+          local ok = self.dict:expire(self.key_prefix .. self.index[key], exptime)
+          -- if key has already expired, remove it from the index
+          if not ok then
+            local idx = self.index[key]
+            self.index[key] = nil
+            self.keys[idx] = nil
+            self.expire_keys[idx] = nil
+            expired = true
+          end
         end
-        break
+        if not expired then
+          break
+        end
       end
       N = N+1
       local ok, err, forcible = self.dict:add(self.key_prefix .. N, key, exptime)

--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -36,16 +36,13 @@ function KeyIndex:remove_expired_keys()
   for i, _ in pairs(self.expire_keys) do
     -- Read i-th key. If it is nil or ttl is < 0, it means it was expired
     local ttl, err = self.dict:ttl(self.key_prefix .. i)
-    if ttl and ttl >=0 or err and err ~= "not found" then
-      goto CONTINUE
-    else
+    if not (ttl and ttl >= 0 or err and err ~= "not found") then
       if self.keys[i] then
         self.index[self.keys[i]] = nil
         self.keys[i] = nil
       end
       self.expire_keys[i] = nil
     end
-    ::CONTINUE::
   end
 end
 

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -145,6 +145,8 @@ function TestPrometheus:setUp()
   self.gauge_exp = self.p:gauge("gauge_exp", "Gauge expire", nil, 1)
   self.gauge_exp_2 = self.p:gauge("gauge_exp_2", "Gauge expire 2", nil, 1)
   self.hist_exp = self.p:histogram("l_exp", "Histogram expire", nil, nil, 1)
+  self.counter_exp_2 = self.p:counter("metric_exp2", "Metric expire 2", nil, 1)
+
 end
 function TestPrometheus.tearDown()
   ngx.logs = nil
@@ -177,6 +179,10 @@ function TestPrometheus:testInitOptions()
   assert(p4.prefix == "foo")
   assert(p4.sync_interval == 3)
   assert(p4.error_metric_name == "foobar")
+  assert(p4.remove_expired_keys_interval ~= 0 and p4.remove_expired_keys_interval ~= "")
+
+  local p5 = require('prometheus').init("metrics", {remove_expired_keys_interval=3})
+  assert(p5.remove_expired_keys_interval == 3)
 
   luaunit.assertEquals(ngx.logs, nil)
 end
@@ -738,7 +744,10 @@ TestKeyIndex = {}
 function TestKeyIndex:setUp()
   self.dict = setmetatable({}, SimpleDict)
   ngx.shared.metrics = self.dict
-  self.key_index = require('prometheus_keys').new(self.dict, '_prefix_')
+  self.key_index = require('prometheus_keys').new(self.dict, {
+    prefix = "_prefix_",
+    remove_expired_keys_interval = 1
+  })
 end
 function TestKeyIndex.tearDown()
   ngx.logs = nil
@@ -944,6 +953,26 @@ function TestPrometheus:testKeyTimeout()
   luaunit.assertEquals(self.dict:get('l_exp_bucket{le="Inf"}'), nil)
   luaunit.assertEquals(self.dict:get('l_exp_count'), nil)
   luaunit.assertEquals(self.dict:get('l_exp_sum'), nil)
+
+end
+
+function TestPrometheus:testKeyTimeout2()
+  self.counter_exp_2:inc(1)
+  sleep(2)
+  self.p._counter:sync()
+  self.counter_exp_2:inc(1)
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric_exp2"), 1)
+  local i = self.p.key_index.index["metric_exp2"]
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), "metric_exp2")
+  luaunit.assertEquals(self.p.key_index.keys[i], "metric_exp2")
+
+  sleep(1)
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("metric_exp2"), nil)
+  luaunit.assertEquals(self.dict:get("__ngx_prom__key_" .. i), nil)
+  luaunit.assertEquals(self.p.key_index.index["metric_exp2"], nil)
+  luaunit.assertEquals(self.p.key_index.keys[i], nil)
 
 end
 


### PR DESCRIPTION
## Description

A worker-local cache (self.lookup and self.index) was used to optimize metric lookups. However, because ngx.shared.dict automatically evicts keys upon TTL expiration but the local Lua memory cache is not automatically synced to reflect this eviction, a drift occurs:

A metric key expires and is removed from the global ngx.shared.dict.
A worker still holds a reference to this metric in its local self.index cache.
When the worker tries to increment/update this metric, KeyIndex:add() sees the metric in self.index and skips adding it to the shared dictionary.
As a result, the metric is completely lost from the KeyIndex:list() scrape cycle, causing missing metrics in Prometheus.

### Solution:

- When a worker looks up a metric to increment/update it, if it has an expiration time set (self.exptime), we ensure the key index relationship is updated via self._key_index:add to put it back into the list.

- regularly sweep the local index and clear out references to keys that have TTL-expired from the global dictionary. This prevents memory leaks in the Lua process and ensures that KeyIndex:list() doesn't iterate over thousands of dead keys.