### PR TITLE
fix: store KeyIndex entries without exptime to allow safe flush_expired usage

### DIFF
--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -133,7 +133,7 @@ function KeyIndex:add(key_or_keys, err_msg_lru_eviction, exptime)
         end
       end
       N = N+1
-      local ok, err, forcible = self.dict:add(self.key_prefix .. N, key, exptime)
+      local ok, err, forcible = self.dict:add(self.key_prefix .. N, key, nil)
       if ok then
         local _, _, forcible2 = self.dict:incr(self.key_count, 1, 0)
         self.keys[N] = key


### PR DESCRIPTION
## Problem

When metrics are registered with an `exptime` (e.g. `expire=300`), the KeyIndex
index entries (`__key:N`) are stored with the same `exptime` via `dict:add()`.

While metric value keys have their TTL refreshed on every `incr`/`set` call,
**the KeyIndex index entries are never refreshed** because `prometheus.lua`'s
`lookup_or_create()` returns early from its local Lua cache on cache hit,
skipping the `key_index:add()` call entirely:

```lua
-- prometheus.lua lookup_or_create()
local full_name = t[LEAF_KEY]
if full_name then
    return full_name  -- cache hit: key_index:add() is never called
end
```

After `exptime` seconds, the index entry expires and gets removed by
`flush_expired()` — even for metrics that are **still actively being recorded**.
On the next `metric_data()` collection, `sync_expired()` detects the missing
index entry and removes it from memory, causing the metric to silently
disappear from Prometheus output.

### Note on existing TTL refresh code

The current code already attempts to refresh TTL for existing keys (lines 118-133):
```lua
if self.index[key] ~= nil then
    if exptime then
        local ok = self.dict:expire(...)
    end
end
```
However, this code is unreachable for active metrics because `lookup_or_create()`'s
local cache prevents `key_index:add()` from being called in the first place.

## Fix

Store KeyIndex entries with `nil` exptime (permanent). Since `dict:add()` only
succeeds once per key (returns `'exists'` error if the key already exists),
changing `exptime` to `nil` here means the index entry is created permanently,
while metric value keys still expire normally via `incr`/`set`.

`flush_expired()` will then only remove expired metric value entries, leaving
the index intact — making it safe to call `flush_expired()` periodically
to reclaim nginx slab memory from expired metrics.

## Reproduction

1. Register a metric with `exptime=300`
2. Send requests so the metric is actively recorded
3. Wait 300 seconds without restarting nginx
4. Call `ngx.shared["prometheus-metrics"]:flush_expired()`
5. Observe: the metric disappears from `/metrics` output despite still being active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed key expiration handling to ensure proper TTL management when adding new cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->