### PR TITLE
feat: release v0.20260623

### DIFF
--- a/rockspec/nginx-lua-prometheus-api7-0.20260623-1.rockspec
+++ b/rockspec/nginx-lua-prometheus-api7-0.20260623-1.rockspec
@@ -1,11 +1,11 @@
 -- Note, this file must have version in its name
 -- (see https://github.com/knyar/nginx-lua-prometheus/issues/27)
 package = "nginx-lua-prometheus-api7"
-version = "0.20250302-1"
+version = "0.20260623-1"
 
 source = {
   url = "git+https://github.com/api7/nginx-lua-prometheus.git",
-  tag = "0.20250302",
+  tag = "0.20260623",
 }
 
 description = {


### PR DESCRIPTION
## Summary

Release `v0.20260623`, bumping the rockspec from `0.20250302` to `0.20260623`.

This release picks up the following change merged since the previous release (`v0.20250302`):

- fix(keys): avoid duplicate metrics from KeyIndex desync (#14)

## Changes

- Rename `rockspec/nginx-lua-prometheus-api7-0.20250302-1.rockspec` → `nginx-lua-prometheus-api7-0.20260623-1.rockspec`
- Bump `version` to `0.20260623-1` and `source.tag` to `0.20260623`

## Note

The PR title must keep the `feat: release v0.20260623` format. On merge to `main`, the release workflow extracts the version from the commit message to create the git tag/GitHub release and upload the rock to luarocks. Please **squash-merge** keeping this title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version and metadata to 0.20260623.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->